### PR TITLE
Prevent CalledProcessError from make agent crash.

### DIFF
--- a/agent/agent_nuclei.py
+++ b/agent/agent_nuclei.py
@@ -365,11 +365,9 @@ class AgentNuclei(
                 subprocess.run(
                     command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True
                 )
+                self._parse_output()
             except subprocess.CalledProcessError as e:
                 logger.error("Error running nuclei %s", e)
-                continue
-
-            self._parse_output()
 
     def _should_process_target(self, scope_urls_regex: Optional[str], url: str) -> bool:
         if scope_urls_regex is None:

--- a/agent/agent_nuclei.py
+++ b/agent/agent_nuclei.py
@@ -361,9 +361,13 @@ class AgentNuclei(
                     if path.exists(template):
                         command.extend(["-t", template])
 
-            subprocess.run(
-                command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True
-            )
+            try:
+                subprocess.run(
+                    command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True
+                )
+            except subprocess.CalledProcessError as e:
+                logger.error("Error running nuclei %s", e)
+                continue
 
             self._parse_output()
 

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -497,15 +497,5 @@ def testAgentNuclei_whenProcessFailed_agentNotCrash(
 
     run_command_mock.assert_called()
     run_command_args = run_command_mock.call_args_list
-    assert run_command_args[1][0][0] == [
-        "/nuclei/nuclei",
-        "-u",
-        "209.235.136.112",
-        "-json",
-        "-irr",
-        "-silent",
-        "-o",
-        "./tests/result_nuclei.json",
-    ]
-
+    assert "/nuclei/nuclei" in run_command_args[1][0][0]
     assert mock_report_vulnerability.call_count == 0

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -1,4 +1,5 @@
 """Unittests for nuclei class."""
+import subprocess
 from typing import Dict
 from typing import List
 from unittest import mock
@@ -461,3 +462,66 @@ def testAgentNuclei_whenMacthedAtIsInvalid_reportVuln(
 
     assert "v3.report.vulnerability" in [a.selector for a in agent_mock]
     assert agent_mock[0].data.get("vulnerability_location") is None
+
+
+@mock.patch("agent.agent_nuclei.OUTPUT_PATH", "./tests/result_nuclei.json")
+def testAgentNuclei_whenProcessFailed_agentNotCrash(
+    requests_mock: rq_mock.mocker.Mocker,
+    scan_message: message.Message,
+    nuclei_agent_args: agent_nuclei.AgentNuclei,
+    agent_persist_mock: Dict[str | bytes, str | bytes],
+    mocker: plugin.MockerFixture,
+) -> None:
+    """Tests running the agent and parsing the json output."""
+    run_command_mock = mocker.patch(
+        "subprocess.run",
+        side_effect=subprocess.CalledProcessError(
+            1,
+            "/nuclei/nuclei -u 209.235.136.112 -json -irr -silent -o ./tests/result_nuclei.json-json -irr "
+            "-silent -o ./tests/result_nuclei.json",
+        ),
+    )
+    mocker.patch("os.path.exists", return_value=True)
+    requests_mock.get(
+        "https://raw.githubusercontent.com/Ostorlab/main/templates/CVE1.yaml",
+        content=b"test1",
+    )
+    requests_mock.get(
+        "https://raw.githubusercontent.com/Ostorlab/main/templates/CVE2.yaml",
+        content=b"test2",
+    )
+    mock_report_vulnerability = mocker.patch(
+        "agent.agent_nuclei.AgentNuclei.report_vulnerability", return_value=None
+    )
+    nuclei_agent_args.process(scan_message)
+
+    run_command_mock.assert_called()
+    run_command_args = run_command_mock.call_args_list
+    assert run_command_args[1][0][0] == [
+        "/nuclei/nuclei",
+        "-u",
+        "209.235.136.112",
+        "-json",
+        "-irr",
+        "-silent",
+        "-o",
+        "./tests/result_nuclei.json",
+    ]
+
+    assert run_command_args[0].args == (
+        [
+            "/nuclei/nuclei",
+            "-u",
+            "209.235.136.112",
+            "-json",
+            "-irr",
+            "-silent",
+            "-o",
+            "./tests/result_nuclei.json",
+            "-t",
+            "CVE1.yaml",
+            "-t",
+            "CVE2.yaml",
+        ],
+    )
+    assert mock_report_vulnerability.call_count == 0

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -508,20 +508,4 @@ def testAgentNuclei_whenProcessFailed_agentNotCrash(
         "./tests/result_nuclei.json",
     ]
 
-    assert run_command_args[0].args == (
-        [
-            "/nuclei/nuclei",
-            "-u",
-            "209.235.136.112",
-            "-json",
-            "-irr",
-            "-silent",
-            "-o",
-            "./tests/result_nuclei.json",
-            "-t",
-            "CVE1.yaml",
-            "-t",
-            "CVE2.yaml",
-        ],
-    )
     assert mock_report_vulnerability.call_count == 0


### PR DESCRIPTION
log:
```Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/ostorlab/agent/agent.py", line 199, in process_message
    self.process(object_message)
  File "/app/agent/agent_nuclei.py", line 117, in process
    self._run_command(targets)
  File "/app/agent/agent_nuclei.py", line 364, in _run_command
    subprocess.run(
  File "/usr/lib/python3.10/subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/nuclei/nuclei', '-u', 'domain://www-linkedin-com.l-0005.l-msedge.net:443', '-j', '-irr', '-silent', '-o', '/tmp/result_nuclei.json']' returned non-zero exit status 1. ```