### PR TITLE
Update from python3.10 to 3.11

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -20,7 +20,7 @@ warn_unused_ignores = True
 disallow_any_unimported = True
 warn_return_any = True
 exclude = .*_pb2.py
-python_version = 3.10
+python_version = 3.11
 
 [mypy-sqlalchemy.*]
 ignore_missing_imports = True

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:latest as base
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y software-properties-common  \
     && add-apt-repository ppa:deadsnakes/ppa \
-    && apt-get remove -y python* \
+    && apt-get remove -y python*
 
 RUN apt-get -y install python3.11 python3.11-dev python3-pip wget zip wireguard iproute2 openresolv  \
     && python3.11 -m pip install --upgrade pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,15 @@
 FROM ubuntu:latest as base
-RUN apt-get update && apt-get -y install python3.10 pip wget zip wireguard iproute2 openresolv
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y software-properties-common  \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get remove -y python* \
+
+RUN apt-get -y install python3.11 python3.11-dev python3-pip wget zip wireguard iproute2 openresolv  \
+    && python3.11 -m pip install --upgrade pip
+
 COPY requirement.txt /requirement.txt
-RUN pip install -r /requirement.txt
+RUN python3.11 -m pip install -r /requirement.txt
 RUN mkdir /nuclei
 WORKDIR /nuclei
 ARG NUCLEI_VERSION=2.9.15
@@ -12,4 +20,4 @@ ENV PYTHONPATH=/app
 COPY agent /app/agent
 COPY ostorlab.yaml /app/agent/ostorlab.yaml
 WORKDIR /app
-CMD ["python3", "/app/agent/agent_nuclei.py"]
+CMD ["python3.11", "/app/agent/agent_nuclei.py"]

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -1,6 +1,6 @@
 kind: Agent
 name: nuclei
-version: 0.6.2
+version: 0.7.0
 image: images/logo.png
 description: |
   This repository is an implementation of [Ostorlab Agent](https://pypi.org/project/ostorlab/) for the [Nuclei Scanner](https://github.com/projectdiscovery/nuclei) by Project Discovery.


### PR DESCRIPTION
**Update from python3.10 to 3.11:**

Steps:
- update python-version in .github/workflows/pylint.yml
- update python-version in .github/workflows/pytest.yml
- update python-version in .github/workflows/mypy.ini
- update python-version in docker file

Steps to test the new version:

- run unit tests using python 3.11 in virtual env

```bash
virtualenv -p python3.11 venv
source venv/bin/activate
pip install -r requirement.txt
pip install -r tests/test-requirement.txt

mypy agent/ tests/
black .
pylint --rcfile=.pylintrc --ignore=tests/ agent/
pylint --rcfile=.pylintrc -d C0103,W0613 tests/
pytest
```

- run test after building the docker image

```bash
ostorlab agent build -f ostorlab.yaml -o dev --no-cache
ostorlab scan run --install --follow=agent/dev/nuclei --agent agent/dev/nuclei ip 8.8.8.8
```