### PR TITLE
Feat : Add CIDR Limit

### DIFF
--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -1,6 +1,6 @@
 kind: Agent
 name: nuclei
-version: 0.7.4
+version: 0.7.5
 image: images/logo.png
 description: |
   This repository is an implementation of [Ostorlab Agent](https://pypi.org/project/ostorlab/) for the [Nuclei Scanner](https://github.com/projectdiscovery/nuclei) by Project Discovery.

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -724,16 +724,14 @@ def testPrepareTargets_whenIPv4AssetReachCIDRLimit_raiseValueError(
     nuclei_agent: agent_nuclei.AgentNuclei,
 ) -> None:
     with pytest.raises(ValueError, match="Subnet mask below 16 is not supported."):
-        assert nuclei_agent.prepare_targets(scan_message_ipv4_with_mask8)
+        nuclei_agent.prepare_targets(scan_message_ipv4_with_mask8)
 
 
 def testPrepareTargets_whenIPv4AssetDoesNotReachCIDRLimit_doesNotRaiseValueError(
     scan_message_network_range: message.Message,
     nuclei_agent: agent_nuclei.AgentNuclei,
 ) -> None:
-    targets = nuclei_agent.prepare_targets(scan_message_network_range)
-
-    assert any(targets) is True
+    nuclei_agent.prepare_targets(scan_message_network_range)
 
 
 def testPrepareTargets_whenIPv6AssetReachCIDRLimit_raiseValueError(
@@ -748,6 +746,4 @@ def testPrepareTargets_whenIPv6AssetDoesNotReachCIDRLimit_doesNotRaiseValueError
     scan_message_ipv6_with_mask112: message.Message,
     nuclei_agent: agent_nuclei.AgentNuclei,
 ) -> None:
-    targets = nuclei_agent.prepare_targets(scan_message_ipv6_with_mask112)
-
-    assert any(targets) is True
+    nuclei_agent.prepare_targets(scan_message_ipv6_with_mask112)

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -727,13 +727,13 @@ def testPrepareTargets_whenIPv4AssetReachCIDRLimit_raiseValueError(
         assert nuclei_agent.prepare_targets(scan_message_ipv4_with_mask8)
 
 
-def testPrepareTargets_whenIPv4AssetDoesBNotReachCIDRLimit_doesNotRaiseValueError(
+def testPrepareTargets_whenIPv4AssetDoesNotReachCIDRLimit_doesNotRaiseValueError(
     scan_message_network_range: message.Message,
     nuclei_agent: agent_nuclei.AgentNuclei,
 ) -> None:
     targets = nuclei_agent.prepare_targets(scan_message_network_range)
 
-    assert any(targets)
+    assert any(targets) is True
 
 
 def testPrepareTargets_whenIPv6AssetReachCIDRLimit_raiseValueError(
@@ -744,10 +744,10 @@ def testPrepareTargets_whenIPv6AssetReachCIDRLimit_raiseValueError(
         nuclei_agent.prepare_targets(scan_message_ipv6_with_mask64)
 
 
-def testPrepareTargets_whenIPv6AssetDoesBNotReachCIDRLimit_doesNotRaiseValueError(
+def testPrepareTargets_whenIPv6AssetDoesNotReachCIDRLimit_doesNotRaiseValueError(
     scan_message_ipv6_with_mask112: message.Message,
     nuclei_agent: agent_nuclei.AgentNuclei,
 ) -> None:
     targets = nuclei_agent.prepare_targets(scan_message_ipv6_with_mask112)
 
-    assert any(targets)
+    assert any(targets) is True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -215,3 +215,35 @@ def nuclei_agent_with_custom_templates(
 
         agent_object = agent_nuclei.AgentNuclei(definition, settings)
         return agent_object
+
+
+@pytest.fixture()
+def scan_message_ipv4_with_mask8() -> message.Message:
+    """Creates a message of type v3.asset.ip.v4 to be used by the agent for testing purposes."""
+    selector = "v3.asset.ip.v4"
+    msg_data = {"host": "192.168.1.17", "mask": "8", "version": 4}
+    return message.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture()
+def scan_message_ipv6_with_mask64() -> message.Message:
+    """Creates a message of type v3.asset.ip.v6 to be used by the agent for testing purposes."""
+    selector = "v3.asset.ip.v6"
+    msg_data = {
+        "host": "2001:db8:3333:4444:5555:6666:7777:8888",
+        "mask": "64",
+        "version": 6,
+    }
+    return message.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture()
+def scan_message_ipv6_with_mask112() -> message.Message:
+    """Creates a message of type v3.asset.ip.v6 to be used by the agent for testing purposes."""
+    selector = "v3.asset.ip.v6"
+    msg_data = {
+        "host": "2001:db8:3333:4444:5555:6666:7777:8888",
+        "mask": "112",
+        "version": 6,
+    }
+    return message.Message.from_data(selector, data=msg_data)


### PR DESCRIPTION
**Enhancement Request: Set Maximum CIDR Prefix Length for Host Limitation**

**Description:**
In order to ensure controlled and efficient scanning, we propose enhancing the current configuration related to CIDR prefix length for IPv4 and IPv6 addresses.

```python
# Maximum CIDR prefix length to limit the number of hosts that can be scanned.
# For IPv4: Setting it to 16 (allowing for 2^(32-16) - 2 = 65,534 hosts).
# For IPv6: Setting it to 112 (allowing for 2^(128-112) = 65,536 hosts).
IPV4_CIDR_LIMIT = 16
IPV6_CIDR_LIMIT = 112
```

---