### PR TITLE
Pin the ubuntu base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest as base
+FROM ubuntu:22.04 as base
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y software-properties-common  \

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -1,6 +1,6 @@
 kind: Agent
 name: nuclei
-version: 1.0.0
+version: 1.0.1
 image: images/logo.png
 description: |
   This repository is an implementation of [Ostorlab Agent](https://pypi.org/project/ostorlab/) for the [Nuclei Scanner](https://github.com/projectdiscovery/nuclei) by Project Discovery.


### PR DESCRIPTION
Since Ubuntu:22.10, both resolvconf and openresolv implementations of resolvconf functionality were removed. We pin the base image for the moment.
For more information: https://bugs.launchpad.net/ubuntu/+source/resolvconf/+bug/1990743