### PR TITLE
Add port to IPs targets

### DIFF
--- a/agent/agent_nuclei.py
+++ b/agent/agent_nuclei.py
@@ -430,7 +430,8 @@ class AgentNuclei(
                         f"Subnet mask below {IPV6_CIDR_LIMIT} is not supported."
                     )
                 ip_network = ipaddress.ip_network(f"{host}/{mask}", strict=False)
-            return [str(h) for h in ip_network.hosts()]
+            port = self._get_port(message)
+            return [f"{h}:{port}" for h in ip_network.hosts()]
 
         elif (domain_name := message.data.get("name")) is not None:
             schema = self._get_schema(message)

--- a/agent/agent_nuclei.py
+++ b/agent/agent_nuclei.py
@@ -313,11 +313,14 @@ class AgentNuclei(
         elif message.data.get("host") is not None:
             host = str(message.data.get("host"))
             mask = message.data.get("mask")
+            port = self._get_port(message)
             if mask is not None:
                 addresses = ipaddress.ip_network(f"{host}/{mask}", strict=False)
-                return self.ip_network_exists("agent_nuclei_asset", addresses)
+                return self.ip_network_exists(
+                    "agent_nuclei_asset", addresses, lambda ip: f"{ip}_{port}"
+                )
             else:
-                return self.set_is_member("agent_nuclei_asset", host)
+                return self.set_is_member("agent_nuclei_asset", f"{host}_{port}")
         else:
             logger.error("Unknown target %s", message)
             return True
@@ -333,11 +336,14 @@ class AgentNuclei(
         elif message.data.get("host") is not None:
             host = str(message.data.get("host"))
             mask = message.data.get("mask")
+            port = self._get_port(message)
             if mask is not None:
                 addresses = ipaddress.ip_network(f"{host}/{mask}", strict=False)
-                self.add_ip_network("agent_nuclei_asset", addresses)
+                self.add_ip_network(
+                    "agent_nuclei_asset", addresses, lambda host: f"{host}_{port}"
+                )
             else:
-                self.set_add("agent_nuclei_asset", host)
+                self.set_add("agent_nuclei_asset", f"{host}_{port}")
         else:
             logger.error("Unknown target %s", message)
             return

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -1,6 +1,6 @@
 kind: Agent
 name: nuclei
-version: 1.0.4
+version: 1.0.5
 image: images/logo.png
 description: |
   This repository is an implementation of [Ostorlab Agent](https://pypi.org/project/ostorlab/) for the [Nuclei Scanner](https://github.com/projectdiscovery/nuclei) by Project Discovery.

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -784,3 +784,12 @@ def testAgentNuclei_whenResultIsInvalidJson_agentShouldHandleExceptionAndDoNotRa
     nuclei_agent_no_url_scope.process(scan_message)
 
     assert len(agent_mock) == 0
+
+
+def testPrepareTargets_whenMessageIsDomainName_shouldReturnDomainName(
+    scan_message_ipv4_with_port: message.Message,
+    nuclei_agent: agent_nuclei.AgentNuclei,
+) -> None:
+    assert nuclei_agent.prepare_targets(scan_message_ipv4_with_port) == [
+        "192.168.0.1:8080"
+    ]

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -795,14 +795,18 @@ def testPrepareTargets_whenMessageIsDomainName_shouldReturnDomainName(
     ]
 
 
+@pytest.mark.parametrize("is_mask_set", [True, False])
 def testNucleiAgent_whenAnIpReceivedWithDifferentPort_shouldScanBothPorts(
     scan_message_ipv4_with_port: message.Message,
     nuclei_agent: agent_nuclei.AgentNuclei,
     mocker: plugin.MockerFixture,
+    is_mask_set: bool,
 ) -> None:
     prepare_targets_mock = mocker.patch(
         "agent.agent_nuclei.AgentNuclei.prepare_targets", return_value=[]
     )
+    if is_mask_set is False:
+        scan_message_ipv4_with_port.data.pop("mask")
     nuclei_agent.process(scan_message_ipv4_with_port)
     scan_message_ipv4_with_port.data["port"] = 8081
 
@@ -811,11 +815,15 @@ def testNucleiAgent_whenAnIpReceivedWithDifferentPort_shouldScanBothPorts(
     assert prepare_targets_mock.call_count == 2
 
 
+@pytest.mark.parametrize("is_mask_set", [True, False])
 def testNucleiAgent_whenAnIpReceivedWithSamePort_shouldScanOnce(
     scan_message_ipv4_with_port: message.Message,
     nuclei_agent: agent_nuclei.AgentNuclei,
     mocker: plugin.MockerFixture,
+    is_mask_set: bool,
 ) -> None:
+    if is_mask_set is False:
+        scan_message_ipv4_with_port.data.pop("mask")
     prepare_targets_mock = mocker.patch(
         "agent.agent_nuclei.AgentNuclei.prepare_targets", return_value=[]
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -235,7 +235,11 @@ def nuclei_agent_with_custom_templates(
             {
                 "name": "template_urls",
                 "value": ["https://template1.yaml", "https://template2.yaml"],
-            }
+            },
+            {
+                "name": "port",
+                "value": 443,
+            },
         ]
         settings = runtime_definitions.AgentSettings(
             key="agent/ostorlab/nuclei",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -280,3 +280,17 @@ def scan_message_ipv6_with_mask112() -> message.Message:
         "version": 6,
     }
     return message.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture()
+def scan_message_ipv4_with_port() -> message.Message:
+    """Creates a message of type v3.asset.ip.v4 to be used by the agent for testing purposes."""
+    selector = "v3.asset.ip.v4.port.service"
+    msg_data = {
+        "host": "192.168.0.1",
+        "port": 8080,
+        "service": "https",
+        "version": 4,
+        "mask": "32",
+    }
+    return message.Message.from_data(selector, data=msg_data)


### PR DESCRIPTION
Based on the discussion [here](https://github.com/orgs/projectdiscovery/discussions/3712), it appears that Nuclei cannot scan all ports. 

To ensure proper integration with the Nmap agent ([Ostorlab Nmap Agent](https://github.com/Ostorlab/agent_nmap)), which emits the open ports, we need to take that information and pass it to the Nuclei agent during the scanning process.