### PR TITLE
Fix compute dna for agent nuclei.

### DIFF
--- a/agent/agent_nuclei.py
+++ b/agent/agent_nuclei.py
@@ -203,7 +203,7 @@ class AgentNuclei(
                 template_info = nuclei_data_dict["info"]
                 extracted_results = nuclei_data_dict.get("extracted-results", [])
                 if len(extracted_results) > 0:
-                    technical_detail += f"""### {template_info.get('name')}: \n"""
+                    technical_detail += f"""### {template_info.get("name")}: \n"""
                     for value in extracted_results:
                         technical_detail += f"""* {value}\n"""
 
@@ -242,9 +242,11 @@ class AgentNuclei(
                 technical_detail += f"""```json\n  {scan_results} \n ``` """
 
                 severity = template_info.get("severity")
-
                 vuln_location = helpers.build_vuln_location(matched_at)
-
+                dna = helpers.compute_dna(
+                    vulnerability_title=template_info.get("name"),
+                    vuln_location=vuln_location,
+                )
                 self.report_vulnerability(
                     entry=kb.Entry(
                         title=template_info.get("name"),
@@ -266,6 +268,7 @@ class AgentNuclei(
                     vulnerability_location=vuln_location,
                     technical_detail=technical_detail,
                     risk_rating=NUCLEI_RISK_MAPPING[severity],
+                    dna=dna,
                 )
 
     def _get_references(
@@ -276,7 +279,7 @@ class AgentNuclei(
         cwe_list = template_info.get("classification", {}).get("cwe-id", [])
         if cwe_list is not None:
             for value in cwe_list:
-                link = f"""https://nvd.nist.gov/vuln/detail/{value.replace('cwe-', '')}.html"""
+                link = f"""https://nvd.nist.gov/vuln/detail/{value.replace("cwe-", "")}.html"""
                 references[value] = link
         cve_list = template_info.get("classification", {}).get("cve-id", [])
         if cve_list is not None:

--- a/agent/helpers.py
+++ b/agent/helpers.py
@@ -160,7 +160,6 @@ def compute_dna(
         str: The DNA for the vulnerability.
     """
     dna_hasher = hashlib.sha256()
-
     if vuln_location is not None:
         dna_hasher.update(json.dumps(vuln_location.to_dict()).encode("utf-8"))
     dna_hasher.update(vulnerability_title.encode("utf-8"))

--- a/agent/helpers.py
+++ b/agent/helpers.py
@@ -1,6 +1,8 @@
 """Helper for nuclei Agent to complete the scan."""
 
+import hashlib
 import ipaddress
+import json
 import logging
 from typing import Tuple, cast, Optional
 from urllib import parse
@@ -142,3 +144,23 @@ def prepare_domain_asset(url: str) -> str:
         asset = result_neloc
 
     return asset
+
+
+def compute_dna(
+    vulnerability_title: str,
+    vuln_location: agent_report_vulnerability_mixin.VulnerabilityLocation,
+) -> str:
+    """Compute the DNA for the vulnerability.
+
+    Args:
+        vulnerability_title: The title of the vulnerability.
+        vuln_location: The location of the vulnerability.
+
+    Returns:
+        str: The DNA for the vulnerability.
+    """
+    dna_hasher = hashlib.sha256()
+    vuln_location_dict = vuln_location.to_dict()
+    dna_hasher.update(vulnerability_title.encode("utf-8"))
+    dna_hasher.update(json.dumps(vuln_location_dict).encode("utf-8"))
+    return dna_hasher.hexdigest()

--- a/agent/helpers.py
+++ b/agent/helpers.py
@@ -148,7 +148,7 @@ def prepare_domain_asset(url: str) -> str:
 
 def compute_dna(
     vulnerability_title: str,
-    vuln_location: agent_report_vulnerability_mixin.VulnerabilityLocation,
+    vuln_location: agent_report_vulnerability_mixin.VulnerabilityLocation | None,
 ) -> str:
     """Compute the DNA for the vulnerability.
 
@@ -160,7 +160,8 @@ def compute_dna(
         str: The DNA for the vulnerability.
     """
     dna_hasher = hashlib.sha256()
-    vuln_location_dict = vuln_location.to_dict()
+
+    if vuln_location is not None:
+        dna_hasher.update(json.dumps(vuln_location.to_dict()).encode("utf-8"))
     dna_hasher.update(vulnerability_title.encode("utf-8"))
-    dna_hasher.update(json.dumps(vuln_location_dict).encode("utf-8"))
     return dna_hasher.hexdigest()

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -43,7 +43,7 @@ def testAgentNuclei_whenBinaryAvailable_RunScan(
     )
     assert (
         mock_report_vulnerability.call_args.kwargs["dna"]
-        == "0fec476337be11e8233fe39532eafaef5e513849f54603029a6ea36e188ab395"
+        == "bf0634a8db1ae003602edeea25ac25327ba5a29b75fb89ea2968c18b69977c1a"
     )
 
 

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -41,6 +41,10 @@ def testAgentNuclei_whenBinaryAvailable_RunScan(
         mock_report_vulnerability.call_args.kwargs["risk_rating"]
         == agent_report_vulnerability_mixin.RiskRating.INFO
     )
+    assert (
+        mock_report_vulnerability.call_args.kwargs["dna"]
+        == "0fec476337be11e8233fe39532eafaef5e513849f54603029a6ea36e188ab395"
+    )
 
 
 @mock.patch("agent.agent_nuclei.OUTPUT_PATH", "./tests/result_nuclei.json")

--- a/tests/helpers_test.py
+++ b/tests/helpers_test.py
@@ -61,3 +61,52 @@ def testBuildVulnLocation_whenMatchedAtIsIpv4WithScheme_returnsValidVulnLocation
     assert ipv4_asset.host == "70.70.70.70"
     assert ipv4_asset.version == 4
     assert ipv4_asset.mask == "32"
+
+
+# add unit test to ensure that when matched_at has path, it is removed
+def testBuildVulnLocation_whenMatchedAtHasPath_returnsVulnLocation() -> None:
+    """Ensure that when matched_at has a path, BuildVulnLocation returns a valid VulnLocation."""
+    matched_at = "https://www.google.com/path/to/something"
+
+    vuln_location = helpers.build_vuln_location(matched_at)
+
+    assert vuln_location is not None
+    domain_asset = vuln_location.asset
+    assert isinstance(domain_asset, domain_name.DomainName)
+    assert domain_asset.name == "www.google.com"
+
+
+def testComputeDna_whenVulnerabilityTitleAndDomainName_returnsDna() -> None:
+    """Ensure that when vulnerability_title and vuln_location is domain name, ComputeDna returns a valid DNA."""
+    vulnerability_title = "Vulnerability Title Domain Name"
+    matched_at = "https://www.google.com/path/to/something"
+    vuln_location = helpers.build_vuln_location(matched_at)
+
+    dna = helpers.compute_dna(vulnerability_title, vuln_location)
+
+    assert dna is not None
+    assert dna == "9d9334f22a089baf127931b9ffa512358531d961d160ddc3ba62e03e7b705400"
+
+
+def testComputeDna_whenVulnerabilityTitleAndIpv4_returnsDna() -> None:
+    """Ensure that when vulnerability_title and vuln_location is IPv4, ComputeDna returns a valid DNA."""
+    vulnerability_title = "Vulnerability Title IPv4"
+    matched_at = "https://70.70.70.70"
+    vuln_location = helpers.build_vuln_location(matched_at)
+
+    dna = helpers.compute_dna(vulnerability_title, vuln_location)
+
+    assert dna is not None
+    assert dna == "fd23df15dec3b9ec54f32b3ff5b46d11ad236c525eaf3e9ded85e913b3b356da"
+
+
+def testComputeDna_whenVulnerabilityTitleAndIpv6_returnsDna() -> None:
+    """Ensure that when vulnerability_title and vuln_location is IPv6, ComputeDna returns a valid DNA."""
+    vulnerability_title = "Vulnerability Title IPv6"
+    matched_at = "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+    vuln_location = helpers.build_vuln_location(matched_at)
+
+    dna = helpers.compute_dna(vulnerability_title, vuln_location)
+
+    assert dna is not None
+    assert dna == "eb5a5627d8627afa6c78b4e9f7d651a0411e717e9e0c3265dd0b903d91d38fe9"

--- a/tests/helpers_test.py
+++ b/tests/helpers_test.py
@@ -84,7 +84,7 @@ def testComputeDna_whenVulnerabilityTitleAndDomainName_returnsDna() -> None:
     dna = helpers.compute_dna(vulnerability_title, vuln_location)
 
     assert dna is not None
-    assert dna == "9d9334f22a089baf127931b9ffa512358531d961d160ddc3ba62e03e7b705400"
+    assert dna == "88041eb3eabb912cf355df800412af278c040bad2c9e0cd8096d811bf9e397c2"
 
 
 def testComputeDna_whenVulnerabilityTitleAndIpv4_returnsDna() -> None:
@@ -96,7 +96,7 @@ def testComputeDna_whenVulnerabilityTitleAndIpv4_returnsDna() -> None:
     dna = helpers.compute_dna(vulnerability_title, vuln_location)
 
     assert dna is not None
-    assert dna == "fd23df15dec3b9ec54f32b3ff5b46d11ad236c525eaf3e9ded85e913b3b356da"
+    assert dna == "e7ccdde03b453b2d1f7a6b52050783b9699f1cb8e048e20e639c8684cade6aab"
 
 
 def testComputeDna_whenVulnerabilityTitleAndIpv6_returnsDna() -> None:
@@ -108,4 +108,4 @@ def testComputeDna_whenVulnerabilityTitleAndIpv6_returnsDna() -> None:
     dna = helpers.compute_dna(vulnerability_title, vuln_location)
 
     assert dna is not None
-    assert dna == "eb5a5627d8627afa6c78b4e9f7d651a0411e717e9e0c3265dd0b903d91d38fe9"
+    assert dna == "c63c3702d0802e579e8c0288f2bac70115a52ad93e8b15f50bee0db2fda41cb1"

--- a/tests/helpers_test.py
+++ b/tests/helpers_test.py
@@ -63,7 +63,6 @@ def testBuildVulnLocation_whenMatchedAtIsIpv4WithScheme_returnsValidVulnLocation
     assert ipv4_asset.mask == "32"
 
 
-# add unit test to ensure that when matched_at has path, it is removed
 def testBuildVulnLocation_whenMatchedAtHasPath_returnsVulnLocation() -> None:
     """Ensure that when matched_at has a path, BuildVulnLocation returns a valid VulnLocation."""
     matched_at = "https://www.google.com/path/to/something"


### PR DESCRIPTION
### Summary
This PR refines the logic for computing DNA (unique identifier) for vulnerabilities by ensuring consistency across different vulnerability reports. The primary issue addressed is that changes in technical details (such as request headers or timestamps) caused variations in the computed DNA, leading to duplicate entries for the same vulnerability. 

### Changes Introduced
- **Updated `compute_dna` logic**
  - Now relies only on `vulnerability_title` and `vuln_location`.
- **Unit tests added/updated**
  - Verified that different location types (domain, IPv4, IPv6) produce valid DNAs.
  - Verified that `build_vuln_location` Extracts only the relevant domain/IP from matched_at, ignoring URL paths.