### PR TITLE
Fix build failure by using ubuntu:24.04 AS base.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
-FROM ubuntu:22.04 as base
+FROM ubuntu:24.04 AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y software-properties-common  \
     && add-apt-repository ppa:deadsnakes/ppa \
     && apt-get remove -y python*
 
-RUN apt-get -y install python3.11 python3.11-dev python3-pip wget zip wireguard iproute2 openresolv  \
-    && python3.11 -m pip install --upgrade pip
-
+RUN apt-get -y install python3.11 python3.11-dev python3-pip wget zip wireguard iproute2
 COPY requirement.txt /requirement.txt
+RUN python3.11 -m pip install --upgrade setuptools
 RUN python3.11 -m pip install -r /requirement.txt
 RUN mkdir /nuclei
 WORKDIR /nuclei


### PR DESCRIPTION
Fix build failure by using ubuntu:24.04 AS base.

After this update the agent was tested locally:

![image](https://github.com/user-attachments/assets/7cb9a811-5d82-48ee-b220-4a30d2b96c7c)
![image](https://github.com/user-attachments/assets/c3cd4093-bfa0-45ac-8bb7-33382401f53b)
